### PR TITLE
Propagate validity check to CLI level as return code 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,22 +16,38 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 )
 
+var SilentErr = errors.New("SilentErr")
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	cobra.CheckErr(newRootCmd().Execute())
+func Execute() error {
+	var err error
+	if err := NewRootCmd().Execute(); err != nil {
+		cobra.CheckErr(err)
+	}
+	return err
 }
 
-func newRootCmd() *cobra.Command {
-	rootCmd := &cobra.Command{
+func NewRootCmd() *cobra.Command {
+	RootCmd := &cobra.Command{
 		Use:   "oslo",
 		Short: "Oslo is a CLI tool for the OpenSLO spec",
+		SilenceErrors: true,
+		SilenceUsage: true,
 	}
 
-	rootCmd.AddCommand(newValidateCmd())
+	RootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		cmd.Println(err)
+		cmd.Println(cmd.UsageString())
+		return SilentErr
+	})
 
-	return rootCmd
+	RootCmd.AddCommand(newValidateCmd())
+
+	return RootCmd
 }

--- a/main.go
+++ b/main.go
@@ -16,9 +16,17 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/openslo/oslo/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		if err != cmd.SilentErr {
+			fmt.Fprintln(os.Stderr, err)
+		}
+	os.Exit(1)
+	}
 }


### PR DESCRIPTION
As mentioned in https://github.com/OpenSLO/oslo/issues/8, reflect properly in the CLI return code whether or not the config has passed a validity check.

[niallm:~/Documents/GitHub/oslo] change-return-code(+31/-7) ± ./oslo validate test/valid.yaml; echo $?
Valid!
0
[niallm:~/Documents/GitHub/oslo] change-return-code(+32/-6) ± ./oslo validate test/invalid.yaml; echo $?
Invalid
  - Conf.Age (less than min)
Error: Error in validation
1

This requires a _fairly_ awkward dance to suppress usage messages given how cobra does things, but this probably isn't a terrible first draft.