### PR TITLE
Adding information to find out more about the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # oslo
 
-CLI tool for the OpenSLO spec
+CLI tool for the [OpenSLO spec](https://github.com/OpenSLO/OpenSLO). For more information also check the website: [openslo.com](https://openslo.com/).
 
 ## Prerequisites
 


### PR DESCRIPTION
Added both spec and website link to get more information to direct users in the right direction.
Currently the readme is a little sparse with that information. Adding some links at the repo level might also be additionally easy for people to learn more about the project.