### PR TITLE
Refactor validate run function to return error

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -116,12 +116,13 @@ func newValidateCmd() *cobra.Command {
 		Use:   "validate",
 		Short: "Validates your yaml file against the OpenSLO spec",
 		Long:  `TODO`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if e := validateFiles(args); e != nil {
-				fmt.Println(e.Error())
-				os.Exit(1)
+				return e
 			}
+
 			fmt.Println("Valid!")
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
## What

`cobra.CheckErr` will print the error and exits with error code `1` so there are no need to call `os.Exit(1)` in this function.