### PR TITLE
Release binary with goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,8 @@
+builds:
+- env:
+    - CGO_ENABLED=0
+  main: .
+  goos:
+    - linux
+    - darwin
+    - windows


### PR DESCRIPTION
## What

I've added a Goreleaser configuration file and a release workflow. 
This CLI tool can be released by pushing tags with semver   format like below:

```console
$ git push origin <vX.Y.Z>
```

## Why

Currently, to run this tool in a local env, it requires Go runtime. 
If we release binaries, the user can easily try this tool without Go installed.