### PR TITLE
manifest: Be more specific with returned types.

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -40,7 +40,7 @@ func readConf(filename string) ([]byte, error) {
 }
 
 // parse takes the provided byte array, parses it, and returns a parsed struct.
-func parse(fileContent []byte, filename string) ([]interface{}, error) {
+func parse(fileContent []byte, filename string) ([]v1alpha.OpenSLOKind, error) {
 	var m manifest.ObjectGeneric
 
 	if err := yaml.Unmarshal(fileContent, &m); err != nil {
@@ -48,7 +48,7 @@ func parse(fileContent []byte, filename string) ([]interface{}, error) {
 	}
 
 	var allErrors []string
-	var parsedStructs []interface{}
+	var parsedStructs []v1alpha.OpenSLOKind
 	switch m.APIVersion {
 	case v1alpha.APIVersion:
 		content, e := v1alpha.Parse(fileContent, m, filename)
@@ -67,7 +67,7 @@ func parse(fileContent []byte, filename string) ([]interface{}, error) {
 }
 
 // validateStruct takes the given struct and validates it.
-func validateStruct(c []interface{}) error {
+func validateStruct(c []v1alpha.OpenSLOKind) error {
 	validate := validator.New()
 
 	_ = validate.RegisterValidation("dateWithTime", isDateWithTimeValid)

--- a/pkg/manifest/v1alpha/objects.go
+++ b/pkg/manifest/v1alpha/objects.go
@@ -19,10 +19,20 @@ const (
 	KindService = "Service"
 )
 
+// OpenSLOKind represents a type of object described by OpenSLO.
+type OpenSLOKind interface {
+	Kind() string
+}
+
 // Service struct which mapped one to one with kind: service yaml definition.
 type Service struct {
 	manifest.ObjectHeader `yaml:",inline"`
 	Spec                  ServiceSpec `yaml:"spec"`
+}
+
+// Kind returns the name of this type.
+func (Service) Kind() string {
+	return "Service"
 }
 
 // ServiceSpec represents content of Spec typical for Service Object.
@@ -34,6 +44,11 @@ type ServiceSpec struct {
 type SLO struct {
 	manifest.ObjectHeader `yaml:",inline"`
 	Spec                  SLOSpec `yaml:"spec"`
+}
+
+// Kind returns the name of this type.
+func (SLO) Kind() string {
+	return "SLO"
 }
 
 // SLOSpec represents content of Spec typical for SLO Object.
@@ -87,7 +102,7 @@ type Calendar struct {
 }
 
 // Parse is responsible for parsing all structs in this apiVersion.
-func Parse(fileContent []byte, m manifest.ObjectGeneric, filename string) (interface{}, error) {
+func Parse(fileContent []byte, m manifest.ObjectGeneric, filename string) (OpenSLOKind, error) {
 	switch m.Kind {
 	case KindService:
 		var content Service


### PR DESCRIPTION
This tightens up the typing around the possible options in the v1alpha package.