### PR TITLE
Fix for multiple errors being printed

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,8 +27,10 @@ func Execute() {
 
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "oslo",
-		Short: "Oslo is a CLI tool for the OpenSLO spec",
+		Use:           "oslo",
+		Short:         "Oslo is a CLI tool for the OpenSLO spec",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 
 	rootCmd.AddCommand(newValidateCmd())


### PR DESCRIPTION
Commands that were returning an error were printing the error twice and also displaying the help output.  This fixes that.