### PR TITLE
Fix G304: Potential file inclusion via variable (gosec) lint failure

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -36,7 +37,7 @@ func readConf(filename string) ([]byte, error) {
 	if filename == "-" {
 		return io.ReadAll(os.Stdin)
 	}
-	fileContent, err := os.ReadFile(filename)
+	fileContent, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Summary
Resolves current linting failures affecting multiple PRs with an error of : 
```
➜  oslo git:(main) golangci-lint run         
cmd/validate.go:39:22: G304: Potential file inclusion via variable (gosec)
        fileContent, err := os.ReadFile(filename)
                            ^
```
