### PR TITLE
Switch to the pull_request_target model for building containers

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
+  pull_request_target:
     branches:
       - main
 


### PR DESCRIPTION
In order to build containers from code forks, we need to be using the `pull_request_target` in our workflow rather than `pull_request` according to https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks

This change should fix #117 