### PR TITLE
Alert Condition : more generic kind & threshold fields

### DIFF
--- a/pkg/manifest/v1/alerts.go
+++ b/pkg/manifest/v1/alerts.go
@@ -37,20 +37,12 @@ type AlertConditionSpec struct {
 	Condition   ConditionType `yaml:"condition" validate:"required"`
 }
 
-// AlertConditionType is the type of an alert condition.
-type AlertConditionType string
-
-const (
-	// AlertConditionTypeBurnRate is the type of a burn rate alert condition.
-	AlertConditionTypeBurnRate AlertConditionType = "burnrate"
-)
-
 // ConditionType is the type of a condition to trigger an alert.
 type ConditionType struct {
-	Kind           *AlertConditionType `yaml:"kind" validate:"required" example:"burnrate"`
-	Threshold      float64             `yaml:"threshold" validate:"required" example:"2"`
-	LookbackWindow string              `yaml:"lookbackWindow" validate:"required,validDuration" example:"1h"`
-	AlertAfter     string              `yaml:"alertAfter" validate:"required,validDuration" example:"5m"`
+	Kind           string  `yaml:"kind" validate:"required" example:"burnrate"`
+	Threshold      float64 `yaml:"threshold" validate:"required" example:"2"`
+	LookbackWindow string  `yaml:"lookbackWindow" validate:"required,validDuration" example:"1h"`
+	AlertAfter     string  `yaml:"alertAfter" validate:"required,validDuration" example:"5m"`
 }
 
 // AlertNotificationTarget is a target for sending alerts.

--- a/pkg/manifest/v1/alerts.go
+++ b/pkg/manifest/v1/alerts.go
@@ -47,8 +47,8 @@ const (
 
 // ConditionType is the type of a condition to trigger an alert.
 type ConditionType struct {
-	Kind           *AlertConditionType `yaml:"kind" validate:"required,oneof=burnrate" example:"burnrate"`
-	Threshold      int                 `yaml:"threshold" validate:"required" example:"2"`
+	Kind           *AlertConditionType `yaml:"kind" validate:"required" example:"burnrate"`
+	Threshold      float64             `yaml:"threshold" validate:"required" example:"2"`
 	LookbackWindow string              `yaml:"lookbackWindow" validate:"required,validDuration" example:"1h"`
 	AlertAfter     string              `yaml:"alertAfter" validate:"required,validDuration" example:"5m"`
 }


### PR DESCRIPTION
- removed `oneof= burnrate ` for `Kind` so it can be also used for other scenarios like SLO/Error budget breach alerts. 
- made `Threshold float64` thus addressing https://github.com/OpenSLO/OpenSLO/issues/137 and make it more suitable for percentage base alerts like error budget remaining.