### PR TITLE
Adding a '--version' command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ builds:
       - linux
       - darwin
       - windows
+    ldflags:
+      - -X main.version={{.Version}}
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+VERSION := $(shell git describe --tags)
 .PHONY: build
 build:
-	go build -o bin/oslo
+	go build -ldflags="-X 'main.version=${VERSION}'" -o bin/oslo
 
 .PHONY: install/checks/spell-and-markdown
 install/checks/spell-and-markdown:

--- a/cmd/oslo/root.go
+++ b/cmd/oslo/root.go
@@ -25,16 +25,17 @@ import (
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	cobra.CheckErr(newRootCmd().Execute())
+func Execute(version string) {
+	cobra.CheckErr(newRootCmd(version).Execute())
 }
 
-func newRootCmd() *cobra.Command {
+func newRootCmd(version string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:           "oslo",
 		Short:         "Oslo is a CLI tool for the OpenSLO spec",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Version:       version,
 	}
 
 	rootCmd.AddCommand(validate.NewValidateCmd())

--- a/cmd/oslo/root_test.go
+++ b/cmd/oslo/root_test.go
@@ -68,7 +68,7 @@ Flags:
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			actual := new(bytes.Buffer)
-			root := newRootCmd()
+			root := newRootCmd("testVersion")
 			root.SetOut(actual)
 			root.SetErr(actual)
 			root.SetArgs(tt.args)

--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
         "golangci",
         "hashicorp",
         "ibartholomew",
+        "ldflags",
         "Logql",
         "mitchellh",
         "msec",

--- a/main.go
+++ b/main.go
@@ -17,9 +17,7 @@ package main
 
 import cmd "github.com/OpenSLO/oslo/cmd/oslo"
 
-var (
-	version string
-)
+var version string
 
 func main() {
 	cmd.Execute(version)

--- a/main.go
+++ b/main.go
@@ -17,6 +17,10 @@ package main
 
 import cmd "github.com/OpenSLO/oslo/cmd/oslo"
 
+var (
+	version string
+)
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(version)
 }


### PR DESCRIPTION
Cobra already provides the `--version` command, I just had to pass the version attribute in the root command.
The value used comes dynamically from Github's releases, so when installing it, it pulls the version from Github and sticks with that with no need for manual interference other than tagging the release (which is already done).
I decided to pass the version in the main file and inject it into the command because I think it makes the most sense - after all it's the build version which includes the whole code base. But I don't have a strong opinion about it.

This was my first time coding in Go so all and every constructive feedback is appreciated.
Resolves #133 