### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ information also check the website: [openslo.com](https://openslo.com/).
 ### From source
 
 1. Checkout this repository
-1. Install oslo with `go get github.com/OpenSLO/oslo`
+1. Install oslo with `go install github.com/OpenSLO/oslo@latest`
 
 ### Homebrew
 


### PR DESCRIPTION
The "go get" command has been deprecated in newer version of go.  Needed to update this to "go install" to help new users have an easier install.