### PR TITLE
Print error when command argument is missing

### DIFF
--- a/cmd/oslo/convert/convert.go
+++ b/cmd/oslo/convert/convert.go
@@ -54,6 +54,7 @@ The output is written to standard output.  If you want to write to a file, you c
 
   oslo convert -f file.yaml -o nobl9 > output.yaml
 `,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If a directory is provided, read all files in the directory.
 			if directory != "" {

--- a/cmd/oslo/validate/validate.go
+++ b/cmd/oslo/validate/validate.go
@@ -29,6 +29,7 @@ func NewValidateCmd() *cobra.Command {
 		Use:   "validate",
 		Short: "Validates your yaml file against the OpenSLO spec.",
 		Long:  `Validates your yaml file against the OpenSLO spec.`,
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if e := validate.Files(args); e != nil {
 				return e


### PR DESCRIPTION
Before the change missing argument for commands `convert` and `validate` ends with `Valid!` e.g. running
```sh
oslo validate
```
instead of
```sh
oslo validate def.yml
```

This PR introduces the below error message
```
Error: requires at least 1 arg(s), only received 0
```
