### PR TITLE
Support Composite SLOs

### DIFF
--- a/internal/fmt/fmt.go
+++ b/internal/fmt/fmt.go
@@ -34,7 +34,9 @@ func Files(out io.Writer, sources []string) error {
 			return err
 		}
 		if i != count-1 {
-			fmt.Fprintln(out, "---")
+			if _, err := fmt.Fprintln(out, "---"); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/manifest/v1/objective.go
+++ b/pkg/manifest/v1/objective.go
@@ -32,19 +32,22 @@ type TimeWindow struct {
 
 // Objective represents single threshold for SLO, for internal usage.
 type Objective struct {
-	DisplayName     string  `yaml:"displayName,omitempty"`
-	Op              string  `yaml:"op,omitempty" example:"lte"`
-	Value           float64 `yaml:"value,omitempty" validate:"numeric,omitempty"`
-	Target          float64 `yaml:"target" validate:"required,numeric,gte=0,lt=1" example:"0.9"`
-	TimeSliceTarget float64 `yaml:"timeSliceTarget,omitempty" validate:"gte=0,lte=1,omitempty" example:"0.9"`
-	TimeSliceWindow string  `yaml:"timeSliceWindow,omitempty" example:"5m"`
+	DisplayName     string     `yaml:"displayName,omitempty"`
+	Op              string     `yaml:"op,omitempty" example:"lte"`
+	Value           float64    `yaml:"value,omitempty" validate:"numeric,omitempty"`
+	Target          float64    `yaml:"target" validate:"required,numeric,gte=0,lt=1" example:"0.9"`
+	TimeSliceTarget float64    `yaml:"timeSliceTarget,omitempty" validate:"gte=0,lte=1,omitempty" example:"0.9"`
+	TimeSliceWindow string     `yaml:"timeSliceWindow,omitempty" example:"5m"`
+	Indicator       *SLIInline `yaml:"indicator,omitempty"`
+	IndicatorRef    *string    `yaml:"indicatorRef,omitempty"`
+	CompositeWeight float64    `yaml:"compositeWeight,omitempty" validate:"gte=0,omitempty"`
 }
 
 // SLOSpec struct which mapped one to one with kind: slo yaml definition, internal use.
 type SLOSpec struct {
 	Description     string       `yaml:"description,omitempty" validate:"max=1050,omitempty"`
 	Service         string       `yaml:"service" validate:"required" example:"webapp-service"`
-	Indicator       *SLIInline   `yaml:"indicator,omitempty" validate:"required_without=IndicatorRef"`
+	Indicator       *SLIInline   `yaml:"indicator,omitempty"`
 	IndicatorRef    *string      `yaml:"indicatorRef,omitempty"`
 	BudgetingMethod string       `yaml:"budgetingMethod" validate:"required,oneof=Occurrences Timeslices" example:"Occurrences"` //nolint:lll
 	TimeWindow      []TimeWindow `yaml:"timeWindow" validate:"required,len=1,dive"`

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -180,6 +180,8 @@ func Test_validateFiles(t *testing.T) {
 					"../../test/v1/slo/slo-no-indicatorref-calendar-no-alerts.yaml",
 					"../../test/v1/slo/slo-no-indicatorref-rolling-alerts.yaml",
 					"../../test/v1/slo/slo-no-indicatorref-rolling-no-alerts.yaml",
+					"../../test/v1/slo/slo-composite-indicatorRef-rolling-no-alerts.yaml",
+					"../../test/v1/slo/slo-composite-no-indicatorRef-rolling-no-alerts.yaml",
 				},
 			},
 			wantErr: false,

--- a/test/v1/slo/slo-composite-indicatorRef-rolling-no-alerts.yaml
+++ b/test/v1/slo/slo-composite-indicatorRef-rolling-no-alerts.yaml
@@ -1,0 +1,21 @@
+apiVersion: openslo/v1
+kind: SLO
+metadata:
+  name: TestSLO
+  displayName: Test SLO # optional
+spec:
+  description: This is a great description # optional
+  service: TheServiceName # name of the service to associate this SLO with
+  timeWindow:
+    - duration: 1d
+      isRolling: true
+  budgetingMethod: Occurrences
+  objectives:
+    - displayName: Foo Total Errors
+      target: 0.98
+      compositeWeight: 1
+      indicatorRef: indicatorRefString # name of the SLI. Required if indicator is not given.
+    - displayName: Bar Total Errors
+      target: 0.99
+      compositeWeight: 2
+      indicatorRef: indicatorRefString # name of the SLI. Required if indicator is not given.

--- a/test/v1/slo/slo-composite-no-indicatorRef-rolling-no-alerts.yaml
+++ b/test/v1/slo/slo-composite-no-indicatorRef-rolling-no-alerts.yaml
@@ -1,0 +1,57 @@
+apiVersion: openslo/v1
+kind: SLO
+metadata:
+  name: TestSLO
+  displayName: Test SLO
+spec:
+  description: This is a great description
+  service: TheServiceName
+  timeWindow:
+    - duration: 1M
+      isRolling: true
+  budgetingMethod: Occurrences
+  objectives:
+    - displayName: Foo Total Errors
+      target: 0.98
+      compositeWeight: 1
+      indicator:
+        metadata:
+          name: foo-error
+          displayName: Foo Error
+        spec:
+          ratioMetric:
+            counter: true
+            good:
+              metricSource:
+                metricSourceRef: datadog-datasource
+                type: Datadog
+                spec:
+                  query: sum:trace.http.request.hits.by_http_status{http.status_code:200}.as_count()
+            total:
+              metricSource:
+                metricSourceRef: datadog-datasource
+                type: Datadog
+                spec:
+                  query: sum:trace.http.request.hits.by_http_status{*}.as_count()
+    - displayName: Bar Total Errors
+      target: 0.99
+      compositeWeight: 2
+      indicator:
+        metadata:
+          name: foo-error
+          displayName: Foo Error
+        spec:
+          ratioMetric:
+            counter: true
+            good:
+              metricSource:
+                metricSourceRef: datadog-datasource
+                type: Datadog
+                spec:
+                  query: sum:trace.http.request.hits.by_http_status{http.status_code:200}.as_count()
+            total:
+              metricSource:
+                metricSourceRef: datadog-datasource
+                type: Datadog
+                spec:
+                  query: sum:trace.http.request.hits.by_http_status{*}.as_count()


### PR DESCRIPTION
Composite SLOs were added into the spec in OpenSLO/OpenSLO#182, however they never made it into the Go struct code.

Essentially, with the new spec, Indicators can be added in the Objective field, as a inline, or ref. A new field is also added for the weight.

By allowing this for Composite SLOs we need to remove the required validation for Indicator within the main SLO Spec.