### PR TITLE
Improve YAML parsing to handle list sequences within SLI spec

### DIFF
--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -1005,7 +1005,9 @@ func printYaml(out io.Writer, object interface{}) error {
 		return fmt.Errorf("issue marshaling content: %w", err)
 	}
 
-	fmt.Fprint(out, "---\n")
+	if _, err = fmt.Fprint(out, "---\n"); err != nil {
+		return err
+	}
 	_, err = out.Write(yml)
 	if err != nil {
 		return fmt.Errorf("issue writing content: %w", err)

--- a/pkg/manifest/v1/indicator_test.go
+++ b/pkg/manifest/v1/indicator_test.go
@@ -81,6 +81,24 @@ spec:
 				},
 			},
 		},
+		{
+			name: "Prometheus - Two labels",
+			yaml: `metricSourceRef: thanos
+type: Prometheus
+spec:
+  query: http_requests_total{}
+  dimensions:
+    - following
+    - another`,
+			want: MetricSource{
+				MetricSourceRef: "thanos",
+				Type:            "Prometheus",
+				MetricSourceSpec: map[string]string{
+					"query":      "http_requests_total{}",
+					"dimensions": "following;another",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR will allow more YAML configurations within the SLI spec as lists were previously not parsed.

Within my org we're wanting to allow our users to see SLOs by cluster, or server. This is likely niche, but we're doing this by allowing users to define the Prometheus labels to scrape. e.g. `sum(http_requests_total{}) by (cluster)`. To do this we're wanting the spec to look like the following.

```yaml
indicator:
    spec:
      ratioMetric:
        total:
          metricSource:
            type: Prometheus
            metricSourceRef: thanos
            spec:
              query: http_requests_total{service="example"}
              dimensions:
                - cluster
                - server
```

This may be niche, but we believe that the spec was written to be open minded regarding the format within the `metricSource.spec`, so this should be supported.

FYI, the output of this within the Go struct matches the existing format with `dimensions` being `cluster;server`